### PR TITLE
fix：上一次仅修改了周的计算方式，但是日计划中周的计算方式没有同步，导致周总结的sql中select不到相应的日计划

### DIFF
--- a/templates/一周/日计划.md
+++ b/templates/一周/日计划.md
@@ -6,13 +6,20 @@
 	.action{$notebox =$v.Box}	
 .action{end}
 
-.action{/*获取当前是第几周*/}
-	.action{$ng_duration := (toDate "2006-01-02" "2021-12-26").Sub now}
-	.action{$weekhours:=mul 7 24}
-	.action{$duration:=sub 0 $ng_duration.Hours }
-	.action{$weeks := add (div (div (now.Sub (toDate "2006-01-02" "2021-12-26")).Hours 24) 7) 1}
-	.action{$today:= (now | date "2006-01")}
-	.action{$weekResult:= (list $today "Week" $weeks| join " ")}
+.action{ $anchorSunday := "2022-12-25" }
+.action{ $yearStartDate := now.Year | printf "%d-01-01" | toDate "2006-01-02" }
+.action{ $ysDateDuration := div ($yearStartDate.Sub (toDate "2006-01-02" $anchorSunday)).Hours 24 }
+.action{ $ysWeekDay := mod $ysDateDuration 7 }
+.action{ $yearStartWeek := add (div (sub $ysDateDuration 1) 7) 1 }
+.action{ if or (eq $ysWeekDay 0) (gt $ysWeekDay 4) }
+    .action{ $yearStartWeek := add $yearStartWeek 1 }
+.action{ end }
+
+.action{ $nowWeek := add (div (div (now.Sub (toDate "2006-01-02" $anchorSunday)).Hours 24) 7) 1 }
+.action{ $weeks := add (sub $nowWeek $yearStartWeek) 1 }
+
+.action{$today:= (now | date "2006-01")}
+.action{$weekResult:= (list $today "Week" $weeks| join " ")}
 
 
 


### PR DESCRIPTION
fix：上一次仅修改了周的计算方式，但是日计划中周的计算方式没有同步，导致周总结的sql中select不到相应的日计划。

修改方式：
将周总结中的逻辑直接复制到日计划中，并且简单修改weeks这个变量